### PR TITLE
Add console

### DIFF
--- a/bin/console.js
+++ b/bin/console.js
@@ -1,0 +1,6 @@
+import repl from 'repl'
+import app from '../src/app.js'
+
+Object.assign(repl.start().context, {
+  app,
+})

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "sqlite3": "^5.1.1"
   },
   "scripts": {
-    "server": "node src/index"
+    "server": "node src/index",
+    "console": "node bin/console"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,18 @@
+import cors from 'express'
+import express from 'express'
+import sqlite from 'sqlite3'
+import ejs from 'ejs'
+
+const db = new sqlite.Database('../db.sqlite')
+
+const app = express()
+
+app.db = db
+
+app.set('view engine', 'ejs')
+
+app.get('/', function(request, response) {
+  response.render('index')
+})
+
+export default app

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,9 @@
-import cors from 'express'
-import express from 'express'
-import sqlite from 'sqlite3'
-import ejs from 'ejs'
+import app from './app.js'
 
-const db = new sqlite.Database('../db.sqlite')
-
-const app = express()
 const port = 4004
-
-app.set('view engine', 'ejs')
-
-app.get('/', function(request, response) {
-  response.render('index')
-})
 
 app.listen(port, function() {
   console.log(`Listening on port ${port}`)
 })
 
-db.close()
+app.db.close()


### PR DESCRIPTION
I wanted to start a console with our app loaded for easier debugging of
stuffs.

To do this I need app to be available for export without starting the
server.

The app can now be started in a repl consol locally with `yarn console`. 

The app object is made available to the local context

